### PR TITLE
Alterar filtro de solicitações por status e ajustar enum

### DIFF
--- a/API/Controllers/SolicitacaoIngressoController.cs
+++ b/API/Controllers/SolicitacaoIngressoController.cs
@@ -44,10 +44,10 @@ namespace API.Controllers
                 return BadRequest(new { message = "Falha ao processar a solicitação de ingresso. Tente novamente mais tarde." });
         }
 
-        [HttpGet("listar-solicitacoes-pendentes")]
-        public IActionResult ListarSolicitacoesPendentes()
+        [HttpGet("listar-solicitacoes-por-status")]
+        public IActionResult ListarSolicitacoesPorStatus([FromQuery] EnumeradorDeStatus status)
         {
-            var solicitacoes = _solicitacaoIngressoService.ListarSolicitacoesPendentes();
+            var solicitacoes = _solicitacaoIngressoService.ListarSolicitacoesPorStatus(status);
             return Ok(solicitacoes);
         }
 

--- a/API/Models/Enums/EnumeradorDeStatus.cs
+++ b/API/Models/Enums/EnumeradorDeStatus.cs
@@ -1,9 +1,12 @@
-﻿namespace API.Models.Enums
+﻿using System.Text.Json.Serialization;
+
+namespace API.Models.Enums
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum EnumeradorDeStatus
     {
-        Pendente,
-        Aprovado,
-        Reprovado
+        Pendente = 0,
+        Aprovado = 1,
+        Reprovado = 2
     }
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,8 +1,6 @@
 using API.Data;
 using API.Models;
 using API.Services;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,7 +32,12 @@ builder.Services.ConfigureApplicationCookie(options =>
     options.LogoutPath = "/auth/logout";
 });
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+                .AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(
+        new System.Text.Json.Serialization.JsonStringEnumConverter());
+});
 
 builder.Services.AddOpenApi();
 var app = builder.Build();

--- a/API/Services/SolicitacaoIngressoService.cs
+++ b/API/Services/SolicitacaoIngressoService.cs
@@ -18,24 +18,38 @@ namespace API.Services
         internal async Task<bool> AprovarSolicitacao(int id)
         {
             var solicitacao = await _context.SolicitacoesIngresso.FindAsync(id);
-            if (solicitacao == null)
+
+            if (solicitacao == null || solicitacao.StatusSolicitacao != EnumeradorDeStatus.Pendente)
                 return false;
 
-            var identityUser = new User
+            var identityUser = _context.Users.FirstOrDefault(u => u.Email == solicitacao.EmailInstitucional && u.UserName == solicitacao.NomeCompleto);
+            if (identityUser == null)
             {
-                UserName = solicitacao.EmailInstitucional,
-                Email = solicitacao.EmailInstitucional,
-            };
-            _context.Users.Add(identityUser);
-            _context.SaveChanges();
+                identityUser = new User
+                {
+                    UserName = solicitacao.EmailInstitucional,
+                    Email = solicitacao.EmailInstitucional,
+                };
 
-            var professorCriado = await _professorService.CriarProfessorAsync(solicitacao.NomeCompleto, solicitacao.Matricula, solicitacao.EmailInstitucional, solicitacao.Departamento, identityUser.Id, identityUser);
+                var result = await _context.Users.AddAsync(identityUser);
 
-            if (!professorCriado)
-                return false;
+                if (result == null) return false;
+            }
+
+            var professorCriado = await _professorService.CriarProfessorAsync(
+                solicitacao.NomeCompleto,
+                solicitacao.Matricula,
+                solicitacao.EmailInstitucional,
+                solicitacao.Departamento,
+                identityUser.Id,
+                identityUser
+            );
+
+            if (!professorCriado) return false;
 
             solicitacao.StatusSolicitacao = EnumeradorDeStatus.Aprovado;
             await _context.SaveChangesAsync();
+
             return true;
         }
 
@@ -47,9 +61,9 @@ namespace API.Services
             return true;
         }
 
-        internal List<SolicitacaoIngresso> ListarSolicitacoesPendentes()
+        internal List<SolicitacaoIngresso> ListarSolicitacoesPorStatus(EnumeradorDeStatus status)
         {
-            return _context.SolicitacoesIngresso.Where(s => s.StatusSolicitacao == EnumeradorDeStatus.Pendente).ToList();
+            return _context.SolicitacoesIngresso.Where(s => s.StatusSolicitacao == status).ToList();
         }
 
         internal async Task<bool> ReprovarSolicitacao(int id)


### PR DESCRIPTION
- Endpoint GET agora permite filtrar solicitações por status via query string.
- Substituído método de listagem para aceitar parâmetro EnumeradorDeStatus.
- Enum EnumeradorDeStatus serializado como string no JSON.
- Configurado JsonStringEnumConverter globalmente nos controllers.
- Aprovação de solicitação agora só permite status pendente.
- Evita duplicidade ao buscar usuário antes de criar novo.
- Listagem de solicitações permite qualquer status.