### PR TITLE
feat: Implementa CRUD de Publicações com imagem de capa

### DIFF
--- a/API/Controllers/PublicacaoController.cs
+++ b/API/Controllers/PublicacaoController.cs
@@ -1,0 +1,148 @@
+﻿using API.DTOs;
+using API.Models;
+using API.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class PublicacaoController(PublicacaoService publicacaoService, UserManager<User> userManager) : ControllerBase
+    {
+        [Authorize(Roles = "Admin")]
+        [HttpPost]
+        [Consumes("multipart/form-data")]
+        public async Task<IActionResult> NovaPublicacao([FromForm] PublicacaoDto dto)
+        {
+            Imagem? imagem = null;
+
+            if (dto.ImagemCapa != null)
+            {
+                using var memoryStream = new MemoryStream();
+
+                await dto.ImagemCapa.CopyToAsync(memoryStream);
+
+                imagem = new Imagem
+                {
+                    Conteudo = memoryStream.ToArray(),
+                    ContentType = dto.ImagemCapa.ContentType,
+                    NomeArquivo = dto.ImagemCapa.FileName,
+                    CriadoEm = DateTime.UtcNow
+                };
+            }
+
+            var publicacao = new Publicacao
+            {
+                Tipo = dto.Tipo,
+                Titulo = dto.Titulo,
+                Descricao = dto.Descricao,
+                Data = DateTime.SpecifyKind(dto.Data, DateTimeKind.Unspecified),
+                Local = dto.Local,
+                ImagemCapa = imagem,
+                PublicadoEm = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified)
+            };
+
+            var userId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrWhiteSpace(userId))
+                return Unauthorized();
+
+            var publicadoPor = await userManager.FindByIdAsync(userId);
+            if (publicadoPor == null)
+                return Unauthorized();
+
+            publicacao.PublicadoPor = publicadoPor;
+            publicacao.PublicadoEm = DateTime.UtcNow;
+
+            var result = await publicacaoService.NovaPublicacao(publicacao);
+
+            if (!result)
+                return BadRequest(new { message = "Falha ao criar a publicação. Tente novamente mais tarde." });
+
+            return Ok(new
+            {
+                message = "Nova publicação criada com sucesso."
+            });
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> ListarPublicacoes([FromQuery] FiltroPublicacaoDto filtro)
+        {
+            var publicacoes = await publicacaoService.ListarPublicacoesAsync(filtro);
+            return Ok(publicacoes);
+        }
+
+        [HttpGet("{id:int}")]
+        public async Task<IActionResult> ObterPublicacaoPorId(int id)
+        {
+            var publicacao = await publicacaoService.ObterPublicacaoPorIdAsync(id);
+
+            if (publicacao == null)
+                return NotFound(new
+                {
+                    message = "Publicação não encontrada."
+                });
+
+            return Ok(publicacao);
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpDelete("{id:int}")]
+        public async Task<IActionResult> DeletarPublicacao(int id)
+        {
+            var result = await publicacaoService.DeletarPublicacaoAsync(id);
+
+            if (!result)
+                return NotFound(new
+                {
+                    message = "Publicação não encontrada."
+                });
+
+            return Ok(new
+            {
+                message = "Publicação deletada com sucesso."
+            });
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPatch("{id:int}")]
+        [Consumes("multipart/form-data")]
+        public async Task<IActionResult> EditarPublicacao(int id, [FromForm] EditarPublicacaoDto dto)
+        {
+            Imagem? imagem = null;
+
+            if (dto.ImagemCapa != null)
+            {
+                using var memoryStream = new MemoryStream();
+
+                await dto.ImagemCapa.CopyToAsync(memoryStream);
+
+                imagem = new Imagem
+                {
+                    Conteudo = memoryStream.ToArray(),
+                    ContentType = dto.ImagemCapa.ContentType,
+                    NomeArquivo = dto.ImagemCapa.FileName,
+
+                    CriadoEm = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified)
+                };
+            }
+
+            var result = await publicacaoService.EditarPublicacaoAsync(id, dto, imagem);
+
+            if (!result)
+            {
+                return NotFound(new
+                {
+                    message = "Publicação não encontrada."
+                });
+            }
+
+            return Ok(new
+            {
+                message = "Publicação atualizada com sucesso."
+            });
+        }
+    }
+}

--- a/API/DTOs/EditarPublicacaoDto.cs
+++ b/API/DTOs/EditarPublicacaoDto.cs
@@ -1,0 +1,14 @@
+﻿using API.Models.Enums;
+
+namespace API.DTOs
+{
+    public class EditarPublicacaoDto
+    {
+        public EnumeradorDeTipoDePublicacao? Tipo { get; set; }
+        public string? Titulo { get; set; }
+        public string? Descricao { get; set; }
+        public DateTime? Data { get; set; }
+        public string? Local { get; set; }
+        public IFormFile? ImagemCapa { get; set; }
+    }
+}

--- a/API/DTOs/FiltroPublicacaoDto.cs
+++ b/API/DTOs/FiltroPublicacaoDto.cs
@@ -1,0 +1,12 @@
+﻿using API.Models.Enums;
+
+namespace API.DTOs
+{
+    public class FiltroPublicacaoDto
+    {
+        public EnumeradorDeTipoDePublicacao? Tipo { get; set; }
+        public EnumeradorDeStatusPublicacaoTemporal? StatusTemporal { get; set; }
+        public DateTime? DataInicio { get; set; }
+        public DateTime? DataFim { get; set; }
+    }
+}

--- a/API/DTOs/PublicacaoDto.cs
+++ b/API/DTOs/PublicacaoDto.cs
@@ -1,0 +1,14 @@
+﻿using API.Models.Enums;
+
+namespace API.DTOs
+{
+    public class PublicacaoDto
+    {
+        public EnumeradorDeTipoDePublicacao Tipo { get; set; }
+        public string Titulo { get; set; } = null!;
+        public string Descricao { get; set; } = null!;
+        public DateTime Data { get; set; }
+        public string? Local { get; set; }
+        public IFormFile? ImagemCapa { get; set; }
+    }
+}

--- a/API/DTOs/Response/PublicacaoResponse.cs
+++ b/API/DTOs/Response/PublicacaoResponse.cs
@@ -1,0 +1,15 @@
+﻿namespace API.DTOs.Response
+{
+    public class PublicacaoResponse
+    {
+        public int Id { get; set; }
+        public string Tipo { get; set; }
+        public string Titulo { get; set; }
+        public string Descricao { get; set; }
+        public DateTime Data { get; set; }
+        public string Local { get; set; }
+        public string NomePublicadoPor { get; set; }
+        public DateTime PublicadoEm { get; set; }
+        public string? ImagemCapaBase64 { get; set; }
+    }
+}

--- a/API/Data/AppDbContext.cs
+++ b/API/Data/AppDbContext.cs
@@ -10,6 +10,8 @@ public class AppDbContext : IdentityDbContext<User>
 
     public DbSet<SolicitacaoIngresso> SolicitacoesIngresso { get; set; }
     public DbSet<Professor> Professores { get; set; }
+    public DbSet<Publicacao> Publicacoes { get; set; }
+    public DbSet<Imagem> Imagens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -50,5 +52,25 @@ public class AppDbContext : IdentityDbContext<User>
         builder.Entity<SolicitacaoIngresso>()
             .Property(s => s.StatusSolicitacao)
             .HasConversion<int>();
+
+        builder.Entity<Publicacao>()
+            .HasOne(p => p.PublicadoPor)
+            .WithMany()
+            .HasForeignKey(p => p.PublicadoPorId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Entity<Publicacao>()
+            .Property(p => p.PublicadoEm)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Entity<Publicacao>()
+            .Property(p => p.Data)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Entity<Publicacao>()
+            .HasOne(p => p.ImagemCapa)
+            .WithMany()
+            .HasForeignKey(p => p.ImagemCapaId)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/API/Migrations/20260510182559_ADD_TBL_Publicacao.Designer.cs
+++ b/API/Migrations/20260510182559_ADD_TBL_Publicacao.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510182559_ADD_TBL_Publicacao")]
+    partial class ADD_TBL_Publicacao
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,34 +24,6 @@ namespace API.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("API.Models.Imagem", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("ContentType")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<byte[]>("Conteudo")
-                        .IsRequired()
-                        .HasColumnType("bytea");
-
-                    b.Property<DateTime>("CriadoEm")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("NomeArquivo")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Imagens");
-                });
 
             modelBuilder.Entity("API.Models.Professor", b =>
                 {
@@ -102,20 +77,17 @@ namespace API.Migrations
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("Data")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Descricao")
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<int?>("ImagemCapaId")
-                        .HasColumnType("integer");
-
                     b.Property<string>("Local")
                         .HasColumnType("text");
 
                     b.Property<DateTime>("PublicadoEm")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("PublicadoPorId")
                         .IsRequired()
@@ -129,8 +101,6 @@ namespace API.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("ImagemCapaId");
 
                     b.HasIndex("PublicadoPorId");
 
@@ -389,18 +359,11 @@ namespace API.Migrations
 
             modelBuilder.Entity("API.Models.Publicacao", b =>
                 {
-                    b.HasOne("API.Models.Imagem", "ImagemCapa")
-                        .WithMany()
-                        .HasForeignKey("ImagemCapaId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
                     b.HasOne("API.Models.User", "PublicadoPor")
                         .WithMany()
                         .HasForeignKey("PublicadoPorId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("ImagemCapa");
 
                     b.Navigation("PublicadoPor");
                 });

--- a/API/Migrations/20260510182559_ADD_TBL_Publicacao.cs
+++ b/API/Migrations/20260510182559_ADD_TBL_Publicacao.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class ADD_TBL_Publicacao : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Publicacoes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Tipo = table.Column<int>(type: "integer", nullable: false),
+                    Titulo = table.Column<string>(type: "text", nullable: false),
+                    Descricao = table.Column<string>(type: "text", nullable: false),
+                    Data = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Local = table.Column<string>(type: "text", nullable: true),
+                    PublicadoPorId = table.Column<string>(type: "text", nullable: false),
+                    PublicadoEm = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Publicacoes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Publicacoes_AspNetUsers_PublicadoPorId",
+                        column: x => x.PublicadoPorId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Publicacoes_PublicadoPorId",
+                table: "Publicacoes",
+                column: "PublicadoPorId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Publicacoes");
+        }
+    }
+}

--- a/API/Migrations/20260510183901_UPD_Publicacao_DateTime.Designer.cs
+++ b/API/Migrations/20260510183901_UPD_Publicacao_DateTime.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510183901_UPD_Publicacao_DateTime")]
+    partial class UPD_Publicacao_DateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,34 +24,6 @@ namespace API.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("API.Models.Imagem", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("ContentType")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<byte[]>("Conteudo")
-                        .IsRequired()
-                        .HasColumnType("bytea");
-
-                    b.Property<DateTime>("CriadoEm")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("NomeArquivo")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Imagens");
-                });
 
             modelBuilder.Entity("API.Models.Professor", b =>
                 {
@@ -108,9 +83,6 @@ namespace API.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<int?>("ImagemCapaId")
-                        .HasColumnType("integer");
-
                     b.Property<string>("Local")
                         .HasColumnType("text");
 
@@ -129,8 +101,6 @@ namespace API.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("ImagemCapaId");
 
                     b.HasIndex("PublicadoPorId");
 
@@ -389,18 +359,11 @@ namespace API.Migrations
 
             modelBuilder.Entity("API.Models.Publicacao", b =>
                 {
-                    b.HasOne("API.Models.Imagem", "ImagemCapa")
-                        .WithMany()
-                        .HasForeignKey("ImagemCapaId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
                     b.HasOne("API.Models.User", "PublicadoPor")
                         .WithMany()
                         .HasForeignKey("PublicadoPorId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("ImagemCapa");
 
                     b.Navigation("PublicadoPor");
                 });

--- a/API/Migrations/20260510183901_UPD_Publicacao_DateTime.cs
+++ b/API/Migrations/20260510183901_UPD_Publicacao_DateTime.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class UPD_Publicacao_DateTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "PublicadoEm",
+                table: "Publicacoes",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Data",
+                table: "Publicacoes",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "PublicadoEm",
+                table: "Publicacoes",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Data",
+                table: "Publicacoes",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+        }
+    }
+}

--- a/API/Migrations/20260510193006_ADD_TBL_IMAGEM.Designer.cs
+++ b/API/Migrations/20260510193006_ADD_TBL_IMAGEM.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510193006_ADD_TBL_IMAGEM")]
+    partial class ADD_TBL_IMAGEM
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Migrations/20260510193006_ADD_TBL_IMAGEM.cs
+++ b/API/Migrations/20260510193006_ADD_TBL_IMAGEM.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class ADD_TBL_IMAGEM : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ImagemCapaId",
+                table: "Publicacoes",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Imagens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Conteudo = table.Column<byte[]>(type: "bytea", nullable: false),
+                    ContentType = table.Column<string>(type: "text", nullable: false),
+                    NomeArquivo = table.Column<string>(type: "text", nullable: false),
+                    CriadoEm = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Imagens", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Publicacoes_ImagemCapaId",
+                table: "Publicacoes",
+                column: "ImagemCapaId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Publicacoes_Imagens_ImagemCapaId",
+                table: "Publicacoes",
+                column: "ImagemCapaId",
+                principalTable: "Imagens",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Publicacoes_Imagens_ImagemCapaId",
+                table: "Publicacoes");
+
+            migrationBuilder.DropTable(
+                name: "Imagens");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Publicacoes_ImagemCapaId",
+                table: "Publicacoes");
+
+            migrationBuilder.DropColumn(
+                name: "ImagemCapaId",
+                table: "Publicacoes");
+        }
+    }
+}

--- a/API/Migrations/20260510200149_UPD_Imagem_DateTime.Designer.cs
+++ b/API/Migrations/20260510200149_UPD_Imagem_DateTime.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510200149_UPD_Imagem_DateTime")]
+    partial class UPD_Imagem_DateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Migrations/20260510200149_UPD_Imagem_DateTime.cs
+++ b/API/Migrations/20260510200149_UPD_Imagem_DateTime.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Migrations
+{
+    /// <inheritdoc />
+    public partial class UPD_Imagem_DateTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/API/Models/Enums/EnumeradorDeStatusPublicacaoTemporal.cs
+++ b/API/Models/Enums/EnumeradorDeStatusPublicacaoTemporal.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace API.Models.Enums
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum EnumeradorDeStatusPublicacaoTemporal
+    {
+        Futuras = 0,
+        Passadas = 1,
+        Todas = 2
+    }
+}

--- a/API/Models/Enums/EnumeradorDeTipoDePublicacao.cs
+++ b/API/Models/Enums/EnumeradorDeTipoDePublicacao.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace API.Models.Enums
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum EnumeradorDeTipoDePublicacao
+    {
+        Evento = 0,
+        Acao = 1,
+        Noticia = 2,
+        Aviso = 3
+    }
+}

--- a/API/Models/Imagem.cs
+++ b/API/Models/Imagem.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace API.Models
+{
+    public class Imagem
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public byte[] Conteudo { get; set; } = null!;
+
+        [Required]
+        public string ContentType { get; set; } = null!;
+
+        [Required]
+        public string NomeArquivo { get; set; } = null!;
+
+        public DateTime CriadoEm { get; set; } = DateTime.Now;
+    }
+}

--- a/API/Models/Publicacao.cs
+++ b/API/Models/Publicacao.cs
@@ -1,0 +1,36 @@
+﻿using API.Models.Enums;
+using System.ComponentModel.DataAnnotations;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace API.Models
+{
+    public class Publicacao
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public EnumeradorDeTipoDePublicacao Tipo { get; set; }
+
+        [Required]
+        public string Titulo { get; set; } = null!;
+
+        [Required]
+        public string Descricao { get; set; } = null!;
+
+        [Required]
+        public DateTime Data { get; set; }
+
+        public string? Local { get; set; }
+
+        [Required]
+        public string PublicadoPorId { get; set; } = null!;
+
+        public User PublicadoPor { get; set; } = null!;
+
+        public DateTime PublicadoEm { get; set; }
+
+        public int? ImagemCapaId { get; set; }
+
+        public Imagem? ImagemCapa { get; set; }
+    }
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -36,10 +36,12 @@ builder.Services.AddCors(options =>
 builder.Services.AddScoped<UsuariosService>();
 builder.Services.AddScoped<ProfessorService>();
 builder.Services.AddScoped<SolicitacaoIngressoService>();
+builder.Services.AddScoped<PublicacaoService>();
 builder.Services.Configure<SmtpSettings>(builder.Configuration.GetSection("Smtp"));
-builder.Services.AddTransient<IEmailSender, EmailSender>();
 builder.Services.AddScoped<EmailTemplateService>();
 builder.Services.AddScoped<EmailService>();
+builder.Services.AddTransient<IEmailSender, EmailSender>();
+
 builder.Services.Configure<DataProtectionTokenProviderOptions>(options =>
 {
     options.TokenLifespan = TimeSpan.FromHours(2);

--- a/API/Services/PublicacaoService.cs
+++ b/API/Services/PublicacaoService.cs
@@ -1,0 +1,168 @@
+﻿using API.Data;
+using API.DTOs;
+using API.DTOs.Response;
+using API.Models;
+using API.Models.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Services
+{
+    public class PublicacaoService(AppDbContext context)
+    {
+        private readonly AppDbContext _context = context;
+        internal async Task<bool> NovaPublicacao(Publicacao publicacao)
+        {
+            if (publicacao == null)
+                return false;
+
+            publicacao.PublicadoEm = DateTime.SpecifyKind(publicacao.PublicadoEm, DateTimeKind.Unspecified);
+            publicacao.Data = DateTime.SpecifyKind(publicacao.Data, DateTimeKind.Unspecified);
+
+            _context.Publicacoes.Add(publicacao);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+        internal async Task<List<PublicacaoResponse>> ListarPublicacoesAsync(FiltroPublicacaoDto filtro)
+        {
+            var query = _context.Publicacoes
+                .Include(p => p.ImagemCapa)
+                .Include(p => p.PublicadoPor)
+                .AsQueryable();
+
+            if (filtro.Tipo.HasValue)
+                query = query.Where(p => p.Tipo == filtro.Tipo.Value);
+
+            var hoje = DateTime.SpecifyKind(
+                DateTime.Now,
+                DateTimeKind.Unspecified
+            );
+
+            if (filtro.StatusTemporal.HasValue)
+            {
+                switch (filtro.StatusTemporal.Value)
+                {
+                    case EnumeradorDeStatusPublicacaoTemporal.Futuras:
+                        query = query.Where(p => p.Data >= hoje);
+                        break;
+
+                    case EnumeradorDeStatusPublicacaoTemporal.Passadas:
+                        query = query.Where(p => p.Data < hoje);
+                        break;
+                }
+            }
+
+            if (filtro.DataInicio.HasValue)
+            {
+                var dataInicio = DateTime.SpecifyKind(
+                    filtro.DataInicio.Value,
+                    DateTimeKind.Unspecified
+                );
+
+                query = query.Where(p => p.Data >= dataInicio);
+            }
+
+            if (filtro.DataFim.HasValue)
+            {
+                var dataFim = DateTime.SpecifyKind(
+                    filtro.DataFim.Value,
+                    DateTimeKind.Unspecified
+                );
+
+                query = query.Where(p => p.Data <= dataFim);
+            }
+
+            var publicacoes = query
+            .Select(p => new PublicacaoResponse
+            {
+                Id = p.Id,
+                Tipo = p.Tipo.ToString(),
+                Titulo = p.Titulo,
+                Descricao = p.Descricao,
+                Data = p.Data,
+                Local = p.Local,
+                PublicadoEm = p.PublicadoEm,
+                NomePublicadoPor = p.PublicadoPor.UserName,
+                ImagemCapaBase64 = p.ImagemCapa != null
+                    ? $"data:{p.ImagemCapa.ContentType};base64,{Convert.ToBase64String(p.ImagemCapa.Conteudo)}"
+                    : null
+            });
+
+            return await publicacoes.ToListAsync();
+        }
+        internal async Task<PublicacaoResponse?> ObterPublicacaoPorIdAsync(int id)
+        {
+            return await _context.Publicacoes
+                .Include(p => p.PublicadoPor)
+                .Include(p => p.ImagemCapa)
+                .Where(p => p.Id == id)
+                .Select(p => new PublicacaoResponse
+                {
+                    Id = p.Id,
+                    Tipo = p.Tipo.ToString(),
+                    Titulo = p.Titulo,
+                    Descricao = p.Descricao,
+                    Data = p.Data,
+                    Local = p.Local,
+                    PublicadoEm = p.PublicadoEm,
+                    NomePublicadoPor = p.PublicadoPor.UserName,
+                    ImagemCapaBase64 = p.ImagemCapa != null
+                    ? $"data:{p.ImagemCapa.ContentType};base64,{Convert.ToBase64String(p.ImagemCapa.Conteudo)}"
+                    : null
+                })
+                .FirstOrDefaultAsync();
+        }
+        internal async Task<bool> DeletarPublicacaoAsync(int id)
+        {
+            var publicacao = await _context.Publicacoes
+                .Include(p => p.ImagemCapa)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (publicacao == null)
+                return false;
+
+            if (publicacao.ImagemCapa != null)
+                _context.Imagens.Remove(publicacao.ImagemCapa);
+
+            _context.Publicacoes.Remove(publicacao);
+
+            await _context.SaveChangesAsync();
+
+            return true;
+        }
+        internal async Task<bool> EditarPublicacaoAsync(int id, EditarPublicacaoDto dto, Imagem? imagem)
+        {
+            var publicacao = await _context.Publicacoes
+                .Include(p => p.ImagemCapa)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (publicacao == null)
+                return false;
+
+            if (dto.Tipo.HasValue)
+                publicacao.Tipo = dto.Tipo.Value;
+
+            if (!string.IsNullOrWhiteSpace(dto.Titulo))
+                publicacao.Titulo = dto.Titulo;
+
+            if (!string.IsNullOrWhiteSpace(dto.Descricao))
+                publicacao.Descricao = dto.Descricao;
+
+            if (dto.Data != default)
+                publicacao.Data = DateTime.SpecifyKind(dto.Data.Value, DateTimeKind.Unspecified);
+
+            if (!string.IsNullOrWhiteSpace(dto.Local))
+                publicacao.Local = dto.Local;
+
+            if (imagem != null)
+            {
+                if (publicacao.ImagemCapa != null)
+                    _context.Imagens.Remove(publicacao.ImagemCapa);
+
+                publicacao.ImagemCapa = imagem;
+            }
+
+            await _context.SaveChangesAsync();
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
- Adiciona endpoints e serviço para CRUD de Publicações
- Suporte a upload de imagem de capa (entidade Imagem)
- Filtros por tipo, status temporal e data
- Criação dos DTOs e enums relacionados
- Ajustes no AppDbContext e migrações para novas tabelas