### PR TITLE
Adiciona campo 'Publica' às publicações e filtros

### DIFF
--- a/API/Controllers/PublicacaoController.cs
+++ b/API/Controllers/PublicacaoController.cs
@@ -40,6 +40,7 @@ namespace API.Controllers
                 Data = DateTime.SpecifyKind(dto.Data, DateTimeKind.Unspecified),
                 Local = dto.Local,
                 ImagemCapa = imagem,
+                Publica = dto.Publica,
                 PublicadoEm = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified)
             };
 

--- a/API/DTOs/EditarPublicacaoDto.cs
+++ b/API/DTOs/EditarPublicacaoDto.cs
@@ -10,5 +10,6 @@ namespace API.DTOs
         public DateTime? Data { get; set; }
         public string? Local { get; set; }
         public IFormFile? ImagemCapa { get; set; }
+        public bool? Publica { get; set; }
     }
 }

--- a/API/DTOs/FiltroPublicacaoDto.cs
+++ b/API/DTOs/FiltroPublicacaoDto.cs
@@ -6,6 +6,7 @@ namespace API.DTOs
     {
         public EnumeradorDeTipoDePublicacao? Tipo { get; set; }
         public EnumeradorDeStatusPublicacaoTemporal? StatusTemporal { get; set; }
+        public bool? Publicas { get; set; }
         public DateTime? DataInicio { get; set; }
         public DateTime? DataFim { get; set; }
     }

--- a/API/DTOs/PublicacaoDto.cs
+++ b/API/DTOs/PublicacaoDto.cs
@@ -10,5 +10,6 @@ namespace API.DTOs
         public DateTime Data { get; set; }
         public string? Local { get; set; }
         public IFormFile? ImagemCapa { get; set; }
+        public bool Publica { get; set; }
     }
 }

--- a/API/DTOs/Response/PublicacaoResponse.cs
+++ b/API/DTOs/Response/PublicacaoResponse.cs
@@ -11,5 +11,6 @@
         public string NomePublicadoPor { get; set; }
         public DateTime PublicadoEm { get; set; }
         public string? ImagemCapaUrl { get; set; }
+        public bool Publica { get; set; }
     }
 }

--- a/API/Models/Publicacao.cs
+++ b/API/Models/Publicacao.cs
@@ -32,5 +32,7 @@ namespace API.Models
         public int? ImagemCapaId { get; set; }
 
         public Imagem? ImagemCapa { get; set; }
+
+        public bool Publica { get; set; }
     }
 }

--- a/API/Services/PublicacaoService.cs
+++ b/API/Services/PublicacaoService.cs
@@ -73,6 +73,9 @@ namespace API.Services
                 query = query.Where(p => p.Data <= dataFim);
             }
 
+            if (filtro.Publicas.HasValue)
+                query = query.Where(p => p.Publica == filtro.Publicas.Value);
+
             var entidades = await query.ToListAsync();
 
             var publicacoes = new List<PublicacaoResponse>();
@@ -97,7 +100,8 @@ namespace API.Services
                     Local = p.Local,
                     PublicadoEm = p.PublicadoEm,
                     NomePublicadoPor = p.PublicadoPor.UserName!,
-                    ImagemCapaUrl = imagemUrl
+                    ImagemCapaUrl = imagemUrl,
+                    Publica = p.Publica
                 });
             }
 
@@ -127,7 +131,8 @@ namespace API.Services
                 Local = p.Local,
                 PublicadoEm = p.PublicadoEm,
                 NomePublicadoPor = p.PublicadoPor.UserName!,
-                ImagemCapaUrl = imagemUrl
+                ImagemCapaUrl = imagemUrl,
+                Publica = p.Publica
             };
         }
         internal async Task<bool> DeletarPublicacaoAsync(int id)
@@ -185,6 +190,9 @@ namespace API.Services
 
                 publicacao.ImagemCapa = imagem;
             }
+
+            if (dto.Publica.HasValue)
+                publicacao.Publica = dto.Publica.Value;
 
             await _context.SaveChangesAsync();
             return true;


### PR DESCRIPTION
Inclui a propriedade booleana 'Publica' no modelo Publicacao, nos DTOs e nos fluxos de criação, edição e filtro. Permite definir e consultar se uma publicação é pública. Ajusta serviços e controller para suportar o novo campo.